### PR TITLE
Autoboot support for WiiFlow via arguments. (Wiimpathy)

### DIFF
--- a/Gamecube/GamecubeMain.cpp
+++ b/Gamecube/GamecubeMain.cpp
@@ -329,10 +329,26 @@ PluginTable plugins[] =
 	  PLUGIN_SLOT_5 };
 }
 
+bool Autoboot;
+char AutobootROM[1024];
+char AutobootPath[1024];
+
 int main(int argc, char *argv[]) 
 {
 	/* INITIALIZE */
 #ifdef HW_RVL
+	if(argc > 2 && argv[1] != NULL && argv[2] != NULL)
+	{
+		Autoboot = true;
+		strncpy(AutobootPath, argv[1], sizeof(AutobootPath));
+		strncpy(AutobootROM, argv[2], sizeof(AutobootROM));
+	}
+	else
+	{
+		Autoboot = false;
+		memset(AutobootPath, 0, sizeof(AutobootPath));
+		memset(AutobootROM, 0, sizeof(AutobootROM));
+	}
 	VM_Init(ARAM_SIZE, MRAM_BACKING);
 	DI_UseCache(false);
 	if (!__di_check_ahbprot()) {
@@ -374,9 +390,15 @@ int main(int argc, char *argv[])
 	  init_network_thread();
   }
 #endif
+
+	if(Autoboot)
+	{
+		menu->Autoboot();
+		Autoboot = false;
+	}
 	
 	while (menu->isRunning()) {}
-	
+
 	// Shut down AESND
 	AESND_Reset();
 

--- a/Gamecube/libgui/MessageBox.cpp
+++ b/Gamecube/libgui/MessageBox.cpp
@@ -120,13 +120,29 @@ void MessageBox::setMessage(const char* string)
 {
 	if (messageFade > 0.0f) messageFade = 0.0f;
 	messageBoxActive = true;
-	FRAME_BUTTONS[0].button->setVisible(true);
-	FRAME_BUTTONS[0].button->setActive(true);
-	FRAME_BUTTONS[1].button->setVisible(false);
-	FRAME_BUTTONS[1].button->setActive(false);
-	FRAME_BUTTONS[2].button->setVisible(false);
-	FRAME_BUTTONS[2].button->setActive(false);
-	setDefaultFocus(FRAME_BUTTONS[0].button);
+
+  if(strstr(string, "Autobooting"))
+  {
+	  messageFade = 1.0f;
+
+	  FRAME_BUTTONS[0].button->setVisible(false);
+	  FRAME_BUTTONS[0].button->setActive(false);
+	  FRAME_BUTTONS[1].button->setVisible(false);
+	  FRAME_BUTTONS[1].button->setActive(false);
+	  FRAME_BUTTONS[2].button->setVisible(false);
+	  FRAME_BUTTONS[2].button->setActive(false);
+	  setDefaultFocus(this);
+  }
+  else
+  {
+	  FRAME_BUTTONS[0].button->setVisible(true);
+	  FRAME_BUTTONS[0].button->setActive(true);
+	  FRAME_BUTTONS[1].button->setVisible(false);
+	  FRAME_BUTTONS[1].button->setActive(false);
+	  FRAME_BUTTONS[2].button->setVisible(false);
+	  FRAME_BUTTONS[2].button->setActive(false);
+	  setDefaultFocus(FRAME_BUTTONS[0].button);
+  }
 
 	currentCursorFrame = Cursor::getInstance().getCurrentFrame();
 	Cursor::getInstance().setCurrentFrame(this);

--- a/Gamecube/menu/FileBrowserFrame.cpp
+++ b/Gamecube/menu/FileBrowserFrame.cpp
@@ -27,6 +27,7 @@
 #include "../libgui/MessageBox.h"
 #include "../libgui/FocusManager.h"
 #include "../libgui/CursorManager.h"
+
 #include "../../PsxCommon.h"
 
 extern "C" {
@@ -451,6 +452,7 @@ extern char CdromId[10];
 extern char CdromLabel[33];
 extern signed char autoSaveLoaded;
 void Func_SetPlayGame();
+void Func_PlayGame();
 extern "C" {
 void newCD(fileBrowser_file *file);
 }
@@ -471,6 +473,16 @@ void fileBrowserFrame_LoadFile(int i)
 		int ret = loadISO( &dir_entries[i] );
 		
 		if(!ret){	// If the read succeeded.
+			if(Autoboot){
+				// FIXME: The MessageBox is a hacky way to fix input not responding.
+				// No time to improve this...
+				menu::MessageBox::getInstance().setMessage("Autobooting game...");
+				Func_SetPlayGame();
+				Func_PlayGame();
+				pMenuContext->setActiveFrame(MenuContext::FRAME_MAIN);
+				Autoboot = false;
+				return;
+			}
 			strcpy(feedback_string, "Loaded ");
 			strncat(feedback_string, filenameFromAbsPath(dir_entries[i].name), 36-7);
 
@@ -547,4 +559,13 @@ void fileBrowserFrame_LoadFile(int i)
 	  }
 	  pMenuContext->setActiveFrame(MenuContext::FRAME_MAIN);
 	}
+}
+
+void fileBrowserFrame_AutoBootFile()
+{
+	int i;
+	for(i = 0; i < num_entries - 1; i++)
+		if(strcasestr(dir_entries[i].name, AutobootROM) != NULL)
+			break;
+	fileBrowserFrame_LoadFile(i);
 }

--- a/Gamecube/menu/FileBrowserFrame.h
+++ b/Gamecube/menu/FileBrowserFrame.h
@@ -45,4 +45,6 @@ private:
 
 };
 
+void fileBrowserFrame_AutoBootFile();
+
 #endif

--- a/Gamecube/menu/LoadRomFrame.cpp
+++ b/Gamecube/menu/LoadRomFrame.cpp
@@ -136,8 +136,16 @@ void Func_LoadFromSD()
 	// Make sure the romFile system is ready before we browse the filesystem
 	isoFile_init( isoFile_topLevel );
 
-	pMenuContext->setActiveFrame(MenuContext::FRAME_FILEBROWSER,loadRomMode);
-	fileBrowserFrame_OpenDirectory(isoFile_topLevel);
+	if(Autoboot)
+	{
+		strncpy(isoFile_topLevel->name, AutobootPath, sizeof(isoFile_topLevel->name));
+		fileBrowserFrame_OpenDirectory(isoFile_topLevel);
+	}
+	else
+	{
+		pMenuContext->setActiveFrame(MenuContext::FRAME_FILEBROWSER,loadRomMode);
+		fileBrowserFrame_OpenDirectory(isoFile_topLevel);
+	}
 }
 
 void Func_LoadFromDVD()
@@ -175,8 +183,16 @@ void Func_LoadFromUSB()
 	// Make sure the romFile system is ready before we browse the filesystem
 	isoFile_init( isoFile_topLevel );
 	
-	pMenuContext->setActiveFrame(MenuContext::FRAME_FILEBROWSER,loadRomMode);
-	fileBrowserFrame_OpenDirectory(isoFile_topLevel);
+	if(Autoboot)
+	{
+		strncpy(isoFile_topLevel->name, AutobootPath, sizeof(isoFile_topLevel->name));
+		fileBrowserFrame_OpenDirectory(isoFile_topLevel);
+	}
+	else
+	{
+		pMenuContext->setActiveFrame(MenuContext::FRAME_FILEBROWSER,loadRomMode);
+		fileBrowserFrame_OpenDirectory(isoFile_topLevel);
+	}
 #else
 	menu::MessageBox::getInstance().setMessage("Available only for Wii");
 #endif

--- a/Gamecube/menu/LoadRomFrame.h
+++ b/Gamecube/menu/LoadRomFrame.h
@@ -35,4 +35,9 @@ private:
 	
 };
 
+// For autoboot (plugin)
+void Func_LoadFromSD();
+void Func_LoadFromDVD();
+void Func_LoadFromUSB();
+
 #endif

--- a/Gamecube/menu/MenuContext.cpp
+++ b/Gamecube/menu/MenuContext.cpp
@@ -55,7 +55,10 @@ MenuContext::MenuContext(GXRModeObj *vmode)
 	menu::Gui::getInstance().addFrame(configureButtonsFrame);
 
 	menu::Focus::getInstance().setFocusActive(true);
-	setActiveFrame(FRAME_MAIN);
+
+	// Don't show the menu if we autoboot a game.
+	if (!strlen(&AutobootROM[0]))
+		setActiveFrame(FRAME_MAIN);
 }
 
 MenuContext::~MenuContext()
@@ -159,4 +162,14 @@ menu::Frame* MenuContext::getFrame(int frameIndex)
 void MenuContext::draw()
 {
 	menu::Gui::getInstance().draw();
+}
+
+void MenuContext::Autoboot()
+{
+	if(strcasestr(AutobootPath,"sd:/") != NULL)
+		Func_LoadFromSD();
+	else
+		Func_LoadFromUSB();
+
+	fileBrowserFrame_AutoBootFile();
 }

--- a/Gamecube/menu/MenuContext.h
+++ b/Gamecube/menu/MenuContext.h
@@ -40,6 +40,7 @@ public:
 	MenuContext(GXRModeObj *vmode);
 	~MenuContext();
 	bool isRunning();
+	void Autoboot();
 	void setActiveFrame(int frameIndex);
 	void setActiveFrame(int frameIndex, int submenu);
 	menu::Frame* getFrame(int frameIndex);
@@ -67,5 +68,9 @@ private:
 	ConfigureButtonsFrame *configureButtonsFrame;
 
 };
+
+extern bool Autoboot;
+extern char AutobootROM[1024];
+extern char AutobootPath[1024];
 
 #endif


### PR DESCRIPTION
This modification adds WiiFlow compatibility (support) to WiiSX for autolaunch a PlayStation 1 game via arguments, from a .ini plugin config file or from arguments on the meta.xml.

Tested and working as expected.