### PR TITLE
Fix compatibility with latest HBC and Wii System Menu which doesn't return to them after exiting WiiSX

### DIFF
--- a/Gamecube/libgui/Gui.cpp
+++ b/Gamecube/libgui/Gui.cpp
@@ -128,7 +128,14 @@ void Gui::draw()
 					*(volatile unsigned int*)0xCC003024 = 0;  //reboot
 			  }
 #else
-				rld();
+				#define HBC_STUB 0x53545542
+				#define HBC_HAXX 0x48415858
+				//Load HBC Stub if STUBAXX signature is present
+				if(*(volatile unsigned int*)0x80001804 == HBC_STUB &&
+					*(volatile unsigned int*)0x80001808 == HBC_HAXX)
+					rld();
+				else // Wii channel support
+					SYS_ResetSystem(SYS_RETURNTOMENU, 0, 0); // Return to the Wii System Menu
 #endif
 			}
 		}


### PR DESCRIPTION
There's still an annoying bug that on latest versions of the Homebrew Channel (HBC) and when loaded WiiSX from Wii forwarder channels that WiiSX refuses to exit to HBC (if loaded from HBC) or to the Wii System Menu (if loaded from a forwarder channel).

This modification fixes said issue.

This was taken from later forks of WiiSX, specifically WiiSXRX by NiuuS.