### PR TITLE
add autoFixes (with game ID database) for GPU 'Fake Busy States', special game correction (xjsxjs197)

### DIFF
--- a/Gamecube/menu/FileBrowserFrame.cpp
+++ b/Gamecube/menu/FileBrowserFrame.cpp
@@ -455,6 +455,44 @@ extern "C" {
 void newCD(fileBrowser_file *file);
 }
 
+// code for check strings (xjsxjs197)
+int ChkString(char * str1, char * str2, int len)
+{
+	int tmpIdx = 0;
+	while (str1[tmpIdx] == str2[tmpIdx])
+	{
+		tmpIdx++;
+		if (tmpIdx >= len)
+		{
+			return 1;
+		}
+	}
+	return 0;
+}
+
+// hack for emulating "gpu busy" in some games
+extern unsigned long dwEmuFixes;
+
+static void CheckGameAutoFix(void)
+{
+    // GPU 'Fake Busy States' hack
+    int autoFixLen = 2;
+    char gpuBusyAutoFixGames[autoFixLen][10] = {
+	// Hot Wheels Turbo Racing
+         "SLUS00964" // NTSC-U
+        ,"SLES02198" // PAL
+	};
+
+    dwEmuFixes = 0; // hack for emulating "gpu busy" in some games
+    int i;
+    for (i = 0; i < autoFixLen; i++)
+    {
+        if (ChkString(CdromId, gpuBusyAutoFixGames[i], strlen(gpuBusyAutoFixGames[i]))) {
+            dwEmuFixes = 0x0001;
+        }
+    }
+}
+
 void fileBrowserFrame_LoadFile(int i)
 {
 	char feedback_string[256] = "Failed to load ISO";
@@ -479,6 +517,7 @@ void fileBrowserFrame_LoadFile(int i)
 			strcat(RomInfo,feedback_string);
 			sprintf(buffer,"\nCD-ROM Label: %s\n",CdromLabel);
 			strcat(RomInfo,buffer);
+			CheckGameAutoFix();
 			sprintf(buffer,"CD-ROM ID: %s\n", CdromId);
 			strcat(RomInfo,buffer);
 			sprintf(buffer,"ISO Size: %d Mb\n",isoFile.size/1024/1024);

--- a/Gamecube/menu/FileBrowserFrame.cpp
+++ b/Gamecube/menu/FileBrowserFrame.cpp
@@ -472,10 +472,12 @@ int ChkString(char * str1, char * str2, int len)
 
 // hack for emulating "gpu busy" in some games
 extern unsigned long dwEmuFixes;
+// For special game correction
+extern unsigned long dwActFixes;
 
 static void CheckGameAutoFix(void)
 {
-    // GPU 'Fake Busy States' hack
+    // GPU 'Fake Busy States' hack autoFix
     int autoFixLen = 2;
     char gpuBusyAutoFixGames[autoFixLen][10] = {
 	// Hot Wheels Turbo Racing
@@ -489,6 +491,24 @@ static void CheckGameAutoFix(void)
     {
         if (ChkString(CdromId, gpuBusyAutoFixGames[i], strlen(gpuBusyAutoFixGames[i]))) {
             dwEmuFixes = 0x0001;
+        }
+    }
+
+    // Special game correction autoFix
+    autoFixLen = 5;
+    char autoFixSpecialGames[autoFixLen][10] = {
+	// Star Wars - Dark Forces
+	 "SLUS00297" // NTSC-U
+	,"SLPS00685" // NTSC-J
+	,"SLES00585" // PAL
+	,"SLES00640" // PAL (Italy)
+	,"SLES00646" // PAL (Spain)
+    };
+    dwActFixes = 0;
+    for (i = 0; i < autoFixLen; i++)
+    {
+        if (ChkString(CdromId, autoFixSpecialGames[i], strlen(autoFixSpecialGames[i]))) {
+            dwActFixes |= 0x100;
         }
     }
 }
@@ -520,6 +540,22 @@ void fileBrowserFrame_LoadFile(int i)
 			CheckGameAutoFix();
 			sprintf(buffer,"CD-ROM ID: %s\n", CdromId);
 			strcat(RomInfo,buffer);
+
+			if (dwEmuFixes)
+			{
+			sprintf(buffer, "GPU 'Fake Busy States' hacked\n");
+			strcat(RomInfo,buffer);
+			}
+			if (dwActFixes)
+			{
+			sprintf(buffer, "Special game auto fixed\n");
+			strcat(RomInfo,buffer);
+			}
+
+			// Switches for painting textured quads as 2 triangles (small glitches, but better shading!)
+			// This function has been automatically started in soft.c and dwActFixes have been determined in gpu code, so need to set it here
+			dwActFixes |= 0x200;
+
 			sprintf(buffer,"ISO Size: %d Mb\n",isoFile.size/1024/1024);
 			strcat(RomInfo,buffer);
 			sprintf(buffer,"Country: %s\n",(!Config.PsxType) ? "NTSC":"PAL");

--- a/PeopsSoftGPU/gpu.c
+++ b/PeopsSoftGPU/gpu.c
@@ -1672,8 +1672,8 @@ ENDVRAM:
        gpuDataC=gpuDataP=0;
        primFunc[gpuCommand]((unsigned char *)gpuDataM);
 
-//       if(dwEmuFixes&0x0001 || dwActFixes&0x0400)      // hack for emulating "gpu busy" in some games
-//        iFakePrimBusy=4;
+       if(dwEmuFixes&0x0001 || dwActFixes&0x0400)      // hack for emulating "gpu busy" in some games
+        iFakePrimBusy=4;
       }
     } 
   }

--- a/PsxCounters.c
+++ b/PsxCounters.c
@@ -148,6 +148,9 @@ u32 _psxRcntRcount( u32 index )
     return count;
 }
 
+// hack for emulating "gpu busy" in some games
+extern unsigned long dwEmuFixes;
+
 static
 void _psxRcntWmode( u32 index, u32 value )
 {

--- a/PsxHw.c
+++ b/PsxHw.c
@@ -261,7 +261,6 @@ u32 psxHwRead32(u32 add) {
                     #ifdef SHOW_DEBUG
                     sprintf(txtbuffer, "Read GPU_STATUS Fake Busy \n");
                     DEBUG_print(txtbuffer, DBG_CORE2);
-                    writeLogFile(txtbuffer);
                     #endif // DISP_DEBUG
                     hard &= ~GPUSTATUS_READYFORVRAM;
                 }

--- a/PsxHw.c
+++ b/PsxHw.c
@@ -25,6 +25,7 @@
 #include "Mdec.h"
 #include "CdRom.h"
 #include "gpu.h"
+#include "Gamecube/DEBUG.h"
 
 //#undef PSXHW_LOG
 //#define PSXHW_LOG printf
@@ -209,6 +210,9 @@ u16 psxHwRead16(u32 add) {
 	return hard;
 }
 
+// hack for emulating "gpu busy" in some games
+extern unsigned long dwEmuFixes;
+
 u32 psxHwRead32(u32 add) {
 	u32 hard;
 
@@ -248,8 +252,25 @@ u32 psxHwRead32(u32 add) {
 #endif
 			return hard;
 		case 0x1f801814:
-			gpuSyncPluginSR();
-			hard = SWAP32(HW_GPU_STATUS);
+		    // hack for emulating "gpu busy" in some games
+		    if (dwEmuFixes)
+            {
+                hard = GPU_readStatus();
+                if( (hard & GPUSTATUS_IDLE) == 0 )
+                {
+                    #ifdef SHOW_DEBUG
+                    sprintf(txtbuffer, "Read GPU_STATUS Fake Busy \n");
+                    DEBUG_print(txtbuffer, DBG_CORE2);
+                    writeLogFile(txtbuffer);
+                    #endif // DISP_DEBUG
+                    hard &= ~GPUSTATUS_READYFORVRAM;
+                }
+            }
+            else
+            {
+                gpuSyncPluginSR();
+                hard = SWAP32(HW_GPU_STATUS);
+            }
 			if (hSyncCount < 240 && (hard & PSXGPU_ILACE_BITS) != PSXGPU_ILACE_BITS)
 				hard |= PSXGPU_LCF & (psxCore.cycle << 20);
 #ifdef PSXHW_LOG

--- a/gpu.h
+++ b/gpu.h
@@ -29,6 +29,9 @@
 #define PSXGPU_ILACE   (1<<22)
 #define PSXGPU_DHEIGHT (1<<19)
 
+#define GPUSTATUS_READYFORVRAM        0x08000000
+#define GPUSTATUS_IDLE                0x04000000
+
 // both must be set for interlace to work
 #define PSXGPU_ILACE_BITS (PSXGPU_ILACE | PSXGPU_DHEIGHT)
 


### PR DESCRIPTION
This implementation of autoFixes for the PCSX-R emulator hack "GPU 'Fake Busy States'" and special game correction makes these games playable on WiiSX:

- Hot Wheels: Turbo Racing (NTSC-U/PAL) - required the GPU 'Fake Busy States' hack to be enabled for play on PCSX-R
- Star Wars: Dark Forces (NTSC-U/PAL) - special game correction required

The autoFixes have a game ID database so they if detect a game CD-ROM ID needs autoFix, then apply it, but if not listed, then do not enable it for avoid conflitct between compatibility.

Picked from xjsxjs197's [WiiStation](https://github.com/xjsxjs197/WiiSXRX_2022). Tested and working.