### PR TITLE
fix BIOS music not being heard (xjsxjs197)

### DIFF
--- a/PsxCommon.h
+++ b/PsxCommon.h
@@ -196,4 +196,18 @@ void EmuUpdate();
 #ifdef __cplusplus
 }
 #endif
+
+// add xjsxjs197 start
+#define LOAD_SWAP16p(ptr) ({u16 __ret, *__ptr=(ptr); __asm__ ("lhbrx %0, 0, %1" : "=r" (__ret) : "r" (__ptr)); __ret;})
+#define LOAD_SWAP32p(ptr) ({u32 __ret, *__ptr=(ptr); __asm__ ("lwbrx %0, 0, %1" : "=r" (__ret) : "r" (__ptr)); __ret;})
+#define STORE_SWAP16p(ptr,val) ({u16 __val=(val), *__ptr=(ptr); __asm__ ("sthbrx %0, 0, %1" : : "r" (__val), "r" (__ptr) : "memory");})
+#define STORE_SWAP32p(ptr,val) ({u32 __val=(val), *__ptr=(ptr); __asm__ ("stwbrx %0, 0, %1" : : "r" (__val), "r" (__ptr) : "memory");})
+#define STORE_SWAP32p2(ptr,val) ({u32 __val=(val); __asm__ ("stwbrx %0, 0, %1" : : "r" (__val), "r" (ptr) : "memory");})
+
+extern u32 tmpVal;
+extern u32 tmpAddr[1];
+extern u16 tmpVal16;
+extern u16 tmpAddr16[1];
+// add xjsxjs197 end
+
 #endif

--- a/dfsound/registers.c
+++ b/dfsound/registers.c
@@ -22,6 +22,7 @@
 #include "externals.h"
 #include "registers.h"
 #include "spu_config.h"
+#include "../PsxCommon.h"
 
 static void SoundOn(int start,int end,unsigned short val);
 static void SoundOff(int start,int end,unsigned short val);
@@ -127,7 +128,8 @@ void CALLBACK DFS_SPUwriteRegister(unsigned long reg, unsigned short val,
       break;
     //-------------------------------------------------//
     case H_SPUdata:
-      *(unsigned short *)(spu.spuMemC + spu.spuAddr) = val;
+      //*(unsigned short *)(spu.spuMemC + spu.spuAddr) = val;
+      STORE_SWAP16p(spu.spuMemC + spu.spuAddr, val);
       spu.spuAddr += 2;
       spu.spuAddr &= 0x7fffe;
       break;
@@ -334,7 +336,8 @@ unsigned short CALLBACK DFS_SPUreadRegister(unsigned long reg)
 
     case H_SPUdata:
      {
-      unsigned short s = *(unsigned short *)(spu.spuMemC + spu.spuAddr);
+      //unsigned short s = *(unsigned short *)(spu.spuMemC + spu.spuAddr);
+      unsigned short s = LOAD_SWAP16p(spu.spuMemC + spu.spuAddr);
       spu.spuAddr += 2;
       spu.spuAddr &= 0x7fffe;
       return s;


### PR DESCRIPTION
There's an issue with the BIOS which its music is not heard when executing the BIOS or booting the games through the BIOS.
Refer to @xjsxjs197's WiiStation code ( https://github.com/xjsxjs197/WiiSXRX_2022/commit/757780eae118aaf2a6d09297444c89cd0a5aecba ) for fix that.