### PR TITLE
Some fixes

### DIFF
--- a/Gamecube/DEBUG.c
+++ b/Gamecube/DEBUG.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <fat.h>
+#include <stdarg.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/dir.h>
@@ -35,6 +36,18 @@ static void check_heap_space(void){
 #endif
 }
 #endif
+
+void lightrec_fprintf(FILE *f, const char *format, ...)
+{
+#ifdef SHOW_DEBUG
+	va_list args;
+	va_start(args, format);
+	vsprintf(txtbuffer, format, args);
+	va_end(args);
+
+	DEBUG_print(txtbuffer,DBG_CORE1);
+#endif
+}
 
 void DEBUG_update() {
 #ifdef SHOW_DEBUG

--- a/dfsound/aesnd.c
+++ b/dfsound/aesnd.c
@@ -21,7 +21,7 @@
 #include <string.h>
 #include "out.h"
 #include "spu_config.h"
-#include "../GameCube/wiisxConfig.h"
+#include "../Gamecube/wiiSXconfig.h"
 
 char audioEnabled;
 static AESNDPB* voice = NULL;

--- a/dfsound/registers.c
+++ b/dfsound/registers.c
@@ -23,6 +23,14 @@
 #include "registers.h"
 #include "spu_config.h"
 
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define HTOLE16(x) __builtin_bswap16(x)
+#define LE16TOH(x) __builtin_bswap16(x)
+#else
+#define HTOLE16(x) (x)
+#define LE16TOH(x) (x)
+#endif
+
 static void SoundOn(int start,int end,unsigned short val);
 static void SoundOff(int start,int end,unsigned short val);
 static void FModOn(int start,int end,unsigned short val);
@@ -127,7 +135,7 @@ void CALLBACK DFS_SPUwriteRegister(unsigned long reg, unsigned short val,
       break;
     //-------------------------------------------------//
     case H_SPUdata:
-      *(unsigned short *)(spu.spuMemC + spu.spuAddr) = val;
+      *(unsigned short *)(spu.spuMemC + spu.spuAddr) = HTOLE16(val);
       spu.spuAddr += 2;
       spu.spuAddr &= 0x7fffe;
       break;
@@ -334,7 +342,7 @@ unsigned short CALLBACK DFS_SPUreadRegister(unsigned long reg)
 
     case H_SPUdata:
      {
-      unsigned short s = *(unsigned short *)(spu.spuMemC + spu.spuAddr);
+      unsigned short s = LE16TOH(*(unsigned short *)(spu.spuMemC + spu.spuAddr));
       spu.spuAddr += 2;
       spu.spuAddr &= 0x7fffe;
       return s;


### PR DESCRIPTION
- First commit fixes build on case-sensitive filesystems
- Second commit adds a lightrec_fprintf( ) function. This can be called by Lightrec (when compiled with `-Dfprintf=lightrec_fprintf`) to show its info message as debug;
- Third commit fixes an endian issue in dfsound. Cherry-picked from https://github.com/notaz/pcsx_rearmed/pull/292