### PR TITLE
Enable reverb effect on settings (forgot to do that when fixing reverb code)

### DIFF
--- a/Gamecube/GamecubeMain.cpp
+++ b/Gamecube/GamecubeMain.cpp
@@ -201,7 +201,7 @@ void loadSettings(int argc, char *argv[])
 	spu_config.iVolume = 1024 - (volume * 192); //Volume="medium" in PEOPSspu
 	spu_config.iUseThread = 0;	// Don't enable, broken on GC/Wii
 	spu_config.iUseFixedUpdates = 1;
-	spu_config.iUseReverb = 0;
+	spu_config.iUseReverb = 1;
 	spu_config.iUseInterpolation = 1;
 	spu_config.iXAPitch = 0;
 	spu_config.iTempo = 0;


### PR DESCRIPTION
I was seeing the changes from user @pcercuei on this PR https://github.com/emukidid/pcsxgc/pull/16, but here the author of that PR forgot to enable the reverb effect in the settings on the Gamecube/GamecubeMain.cpp file.

Here i enable it for finish enabling the reverb effect on PCSXGC.
NOTE: please merge this PR after mergiong the previous one by @pcercuei https://github.com/emukidid/pcsxgc/pull/16