### PR TITLE
Fix Dithering setting saving

### DIFF
--- a/Gamecube/GamecubeMain.cpp
+++ b/Gamecube/GamecubeMain.cpp
@@ -85,6 +85,7 @@ char biosDevice;
 char LoadCdBios=0;
 char frameLimit;
 char frameSkip;
+char useDithering;
 extern char audioEnabled;
 char volume;
 char showFPSonScreen;
@@ -142,6 +143,7 @@ static struct {
   { "BootThruBios", &LoadCdBios, BOOTTHRUBIOS_NO, BOOTTHRUBIOS_YES },
   { "LimitFrames", &frameLimit, FRAMELIMIT_NONE, FRAMELIMIT_AUTO },
   { "SkipFrames", &frameSkip, FRAMESKIP_DISABLE, FRAMESKIP_ENABLE },
+  { "Dithering", &useDithering, USEDITHER_NONE, USEDITHER_ALWAYS },
   { "PadAutoAssign", &padAutoAssign, PADAUTOASSIGN_MANUAL, PADAUTOASSIGN_AUTOMATIC },
   { "PadType1", &padType[0], PADTYPE_NONE, PADTYPE_WII },
   { "PadType2", &padType[1], PADTYPE_NONE, PADTYPE_WII },
@@ -175,7 +177,7 @@ void loadSettings(int argc, char *argv[])
 	printToSD        = 0; // Disable SD logging
 	frameLimit		 = 1; // Auto limit FPS
 	frameSkip		 = 0; // Disable frame skipping
-	iUseDither		 = 1; // Default dithering
+	useDithering		 = 1; // Default dithering (set to 0 (disabled) in PEOPSgpu)
 	saveEnabled      = 0; // Don't save game
 	nativeSaveDevice = 0; // SD
 	saveStateDevice	 = 0; // SD
@@ -314,6 +316,7 @@ void loadSettings(int argc, char *argv[])
 
 	//Synch settings with Config
 	Config.Cpu=dynacore;
+	iUseDither = useDithering;
 }
 
 void ScanPADSandReset(u32 dummy) 

--- a/Gamecube/menu/SettingsFrame.cpp
+++ b/Gamecube/menu/SettingsFrame.cpp
@@ -985,6 +985,7 @@ void Func_DitheringNone()
 		FRAME_BUTTONS[i].button->setSelected(false);
 	FRAME_BUTTONS[25].button->setSelected(true);
 	iUseDither = USEDITHER_NONE;
+	useDithering = iUseDither;
 	GPUsetframelimit(0);
 }
 
@@ -994,6 +995,7 @@ void Func_DitheringDefault()
 		FRAME_BUTTONS[i].button->setSelected(false);
 	FRAME_BUTTONS[26].button->setSelected(true);
 	iUseDither = USEDITHER_DEFAULT;
+	useDithering = iUseDither;
 	GPUsetframelimit(0);
 }
 
@@ -1003,6 +1005,7 @@ void Func_DitheringAlways()
 		FRAME_BUTTONS[i].button->setSelected(false);
 	FRAME_BUTTONS[27].button->setSelected(true);
 	iUseDither = USEDITHER_ALWAYS;
+	useDithering = iUseDither;
 	GPUsetframelimit(0);
 }
 

--- a/Gamecube/wiiSXconfig.h
+++ b/Gamecube/wiiSXconfig.h
@@ -89,6 +89,7 @@ enum frameSkip
 };
 
 extern int iUseDither;
+extern char useDithering;
 enum iUseDither
 {
 	USEDITHER_NONE=0,

--- a/PeopsSoftGPU/cfg.c
+++ b/PeopsSoftGPU/cfg.c
@@ -891,7 +891,7 @@ void ReadConfig(void)
  iUseGammaVal=2048;
  iUseScanLines=0;
  iUseNoStretchBlt=0;
- iUseDither=0;
+ iUseDither = useDithering;
  iShowFPS=0;
  iSysMemory=0;
  iStopSaver=0;


### PR DESCRIPTION
This issue has always plagued WiiSX/CubeSX since forever, and i was always upset with that bug, so i decided to finally take the situation of this in my hands and after a lot of trial and error, i finally fixed it.

Now when you hit Save settings after changing the Dithering setting, the Dithering setting will be saved as it should be and will be loaded the next time you start the emulator.

The default value for the "Default" setting will be set by the cfg.c file of P.E.Op.S. Soft GPU (seems that iUseDither is set to 0 by default?)