### PR TITLE
GC: Use minimum GX fifo size

### DIFF
--- a/Gamecube/GamecubeMain.cpp
+++ b/Gamecube/GamecubeMain.cpp
@@ -65,7 +65,6 @@ extern u32 __di_check_ahbprot(void);
 
 u32* xfb[3] = { NULL, NULL, NULL };	/*** Framebuffers ***/
 GXRModeObj *vmode;				/*** Graphics Mode Object ***/
-#define DEFAULT_FIFO_SIZE ( 256 * 1024 )
 BOOL hasLoadedISO = FALSE;
 fileBrowser_file isoFile;  //the ISO file
 fileBrowser_file cddaFile; //the CDDA file

--- a/Gamecube/libgui/GraphicsGX.cpp
+++ b/Gamecube/libgui/GraphicsGX.cpp
@@ -21,9 +21,6 @@
 #include <math.h>
 #include "GraphicsGX.h"
 
-#define DEFAULT_FIFO_SIZE		(256 * 1024)
-
-
 extern "C" unsigned int usleep(unsigned int us);
 void video_mode_init(GXRModeObj *rmode, u32 *fb1, u32 *fb2, u32 *fb3);
 
@@ -111,9 +108,9 @@ void Graphics::init()
 	void *gpfifo = NULL;
 	GXColor background = {0, 0, 0, 0xff};
 
-	gpfifo = memalign(32,DEFAULT_FIFO_SIZE);
-	memset(gpfifo,0,DEFAULT_FIFO_SIZE);
-	GX_Init(gpfifo,DEFAULT_FIFO_SIZE);
+	gpfifo = memalign(32,GX_FIFO_MINSIZE);
+	memset(gpfifo,0,GX_FIFO_MINSIZE);
+	GX_Init(gpfifo,GX_FIFO_MINSIZE);
 	GX_SetCopyClear(background, GX_MAX_Z24);
 
 	GX_SetViewport(0,0,vmode->fbWidth,vmode->efbHeight,0,1);


### PR DESCRIPTION
We don't need more than that.

This reduces RAM usage by 192 KiB.