### PR TITLE
GC: Force 60 Hz on PAL consoles

### DIFF
--- a/Gamecube/libgui/GraphicsGX.cpp
+++ b/Gamecube/libgui/GraphicsGX.cpp
@@ -55,14 +55,14 @@ Graphics::Graphics(GXRModeObj *rmode)
 		}
 #endif
 		if (memcmp( &vmode_phys, &TVPal528IntDf, sizeof(GXRModeObj)) == 0)
-			memcpy( &vmode_phys, &TVPal576IntDfScale, sizeof(GXRModeObj));
+			memcpy( &vmode_phys, &TVEurgb60Hz480IntDf, sizeof(GXRModeObj));
 		break;
 	case VIDEOMODE_NTSC:
 		vmode = &TVNtsc480IntDf;
 		memcpy( &vmode_phys, vmode, sizeof(GXRModeObj));
 		break;
 	case VIDEOMODE_PAL:
-		vmode = &TVPal576IntDfScale;
+		vmode = &TVEurgb60Hz480IntDf;
 		memcpy( &vmode_phys, vmode, sizeof(GXRModeObj));
 		break;
 	case VIDEOMODE_PROGRESSIVE:


### PR DESCRIPTION
Televisions that only support 50 Hz are far gone, all TVs since the 90s or so support PAL-60. Therefore, it is relatively safe to enable PAL-60 unconditionally. This has the huge benefit that NTSC games running at 60 Hz will look much smoother than when trying to run them on a 50 Hz screen.