### PR TITLE
Add missing cdrIsoMultidiskSelect command to Swap CD code from upstream PCSX-ReARMed.

### DIFF
--- a/Gamecube/GamecubeMain.cpp
+++ b/Gamecube/GamecubeMain.cpp
@@ -434,6 +434,7 @@ int loadISOSwap(fileBrowser_file* file) {
 	
 	SysPrintf("selected file: %s\n", &file->name[0]);
 
+	cdrIsoMultidiskSelect++;
 	CdromId[0] = '\0';
 	CdromLabel[0] = '\0';
 	


### PR DESCRIPTION
Adds the missing command cdrIsoMultidiskSelect++ to the Swap CD (Multi-disk) command.
Reference: https://github.com/libretro/pcsx_rearmed/blob/master/frontend/menu.c#L2271

The SBI detection logics/code also depends of this command/variable, and Libretro PCSX-ReARMed has this command, so let's add it to WiiSX too.