### PR TITLE
Add missing cdrIsoMultidiskSelect command to Swap CD code from upstream PCSX-ReARMed.

### DIFF
--- a/Gamecube/GamecubeMain.cpp
+++ b/Gamecube/GamecubeMain.cpp
@@ -39,6 +39,7 @@
 #include <libpcsxcore/r3000a.h>
 #include <libpcsxcore/sio.h>
 #include <libpcsxcore/cdrom.h>
+#include <libpcsxcore/cdriso.h>
 #include "wiiSXconfig.h"
 #include "menu/MenuContext.h"
 extern "C" {
@@ -434,6 +435,7 @@ int loadISOSwap(fileBrowser_file* file) {
 	
 	SysPrintf("selected file: %s\n", &file->name[0]);
 
+	cdrIsoMultidiskSelect++;
 	CdromId[0] = '\0';
 	CdromLabel[0] = '\0';
 	


### PR DESCRIPTION
Adds the missing command cdrIsoMultidiskSelect++ to the Swap CD (Multi-disk) command.

SBI detection logics also depends of this command/variable, and Libretro PCSX-ReARMed has this command.